### PR TITLE
enable allowCrossProtocolRedirects

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/DataSourceUtil.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/DataSourceUtil.java
@@ -45,7 +45,8 @@ class DataSourceUtil {
     }
 
     static HttpDataSource.Factory buildHttpDataSourceFactory(Context context, DefaultBandwidthMeter bandwidthMeter) {
-        return new DefaultHttpDataSourceFactory(getUserAgent(context), bandwidthMeter);
+        // DefaultHttpDataSourceFactory(String userAgent, TransferListener<? super DataSource> listener, int connectTimeoutMillis, int readTimeoutMillis, boolean allowCrossProtocolRedirects) 
+        return new DefaultHttpDataSourceFactory(getUserAgent(context), bandwidthMeter, 20*1000, 20*1000, true);
     }
 
 }


### PR DESCRIPTION
A `react-native-video` component should support cross-origin redirects, as many video CDNs / systems use those (e.g. twitch, filmon)

Consider this PR as a heads up that this should be enabled, but not strictly mergable, as I've hardcoded some timeout values. I thought that 20s is fair enough. 

What do you think?
